### PR TITLE
Debug/spi status

### DIFF
--- a/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibrary.cpp
+++ b/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibrary.cpp
@@ -1,0 +1,44 @@
+#include <SPI.h>
+#include "powerSTEP01ArduinoLibrary.h"
+
+int powerSTEP::_numBoards;
+
+// Constructors
+powerSTEP::powerSTEP(int position, int CSPin, int resetPin, int busyPin)
+{
+  _CSPin = CSPin;
+  _position = position;
+  _resetPin = resetPin;
+  _busyPin = busyPin;
+  _numBoards++;
+  _SPI = &SPI;
+}
+
+powerSTEP::powerSTEP(int position, int CSPin, int resetPin)
+{
+  _CSPin = CSPin;
+  _position = position;
+  _resetPin = resetPin;
+  _busyPin = -1;
+  _numBoards++;
+  _SPI = &SPI;
+}
+
+void powerSTEP::SPIPortConnect(SPIClass *SPIPort)
+{
+  _SPI = SPIPort;
+}
+
+int powerSTEP::busyCheck(void)
+{
+  if (_busyPin == -1)
+  {
+    if (getParam(STATUS) & 0x0002) return 0;
+    else                           return 1;
+  }
+  else 
+  {
+    if (digitalRead(_busyPin) == HIGH) return 0;
+    else                               return 1;
+  }
+}

--- a/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibrary.h
+++ b/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibrary.h
@@ -1,0 +1,259 @@
+// Originally the SparkFun AutoDriver library,
+// modified by Elliot Baptist in January 2017
+// to work with the powerSTEP01 stepper driver IC
+
+#ifndef powerSTEP_h
+#define powerSTEP_h
+
+#include "Arduino.h"
+#include <SPI.h>
+#include "powerSTEP01SPINConstants.h"
+
+class powerSTEP
+{
+	public:
+	// Constructors. We'll ALWAYS want a CS pin and a reset pin, but we may
+	//  not want a busy pin. By using two constructors, we make it easy to
+	//  allow that.
+	powerSTEP(int position, int CSPin, int resetPin, int busyPin);
+	powerSTEP(int position, int CSPin, int resetPin);
+
+	void SPIPortConnect(SPIClass *SPIPort);
+
+	// These are super-common things to do: checking if the device is busy,
+	//  and checking the status of the device. We make a couple of functions
+	//  for that.
+	int busyCheck();
+	int getStatus();
+
+	// Some users will want to do things other than what we explicitly provide
+	//  nice functions for; give them unrestricted access to the parameter
+	//  registers.
+	void setParam(byte param, unsigned long value);
+	long getParam(byte param);
+
+	// Lots of people just want Commands That Work; let's provide them!
+	// Start with some configuration commands
+	void setLoSpdOpt(boolean enable);
+	void configSyncPin(byte pinFunc, byte syncSteps);
+	void configStepMode(byte stepMode);
+
+	void voltageMode(byte stepMode);
+	void currentMode(byte stepMode);
+
+	void setMaxSpeed(float stepsPerSecond);
+	void setMinSpeed(float stepsPerSecond);
+	void setFullSpeed(float stepsPerSecond);
+	void setAcc(float stepsPerSecondPerSecond);
+	void setDec(float stepsPerSecondPerSecond);
+	void setMaxSpeedRaw(unsigned long integerSpeed);
+	void setMinSpeedRaw(unsigned long integerSpeed);
+	void setFullSpeedRaw(unsigned long integerSpeed);
+	void setAccRaw(unsigned long integerSpeed);
+	void setDecRaw(unsigned long integerSpeed);
+	void setOCThreshold(byte threshold);
+	void setPWMFreq(int divisor, int multiplier);
+	void setSlewRate(int slewRate);
+	void setOCShutdown(int OCShutdown);
+	void setVoltageComp(int vsCompMode);
+	void setSwitchMode(int switchMode);
+	void setOscMode(int oscillatorMode);
+	void setAccKVAL(byte kvalInput);
+	void setDecKVAL(byte kvalInput);
+	void setRunKVAL(byte kvalInput);
+	void setHoldKVAL(byte kvalInput);
+
+	void setAccTVAL(byte tvalInput);
+	void setDecTVAL(byte tvalInput);
+	void setRunTVAL(byte tvalInput);
+	void setHoldTVAL(byte tvalInput);
+
+	boolean getLoSpdOpt();
+	// getSyncPin
+	byte getStepMode();
+	float getMaxSpeed();
+	float getMinSpeed();
+	float getFullSpeed();
+	float getAcc();
+	float getDec();
+	unsigned long getMaxSpeedRaw();
+	unsigned long getMinSpeedRaw();
+	unsigned long getFullSpeedRaw();
+	unsigned long getAccRaw();
+	unsigned long getDecRaw();
+	byte getOCThreshold();
+	int getPWMFreqDivisor();
+	int getPWMFreqMultiplier();
+	int getSlewRate();
+	int getOCShutdown();
+	int getVoltageComp();
+	int getSwitchMode();
+	int getOscMode();
+	byte getAccKVAL();
+	byte getDecKVAL();
+	byte getRunKVAL();
+	byte getHoldKVAL();
+
+	byte getAccTVAL();
+	byte getDecTVAL();
+	byte getRunTVAL();
+	byte getHoldTVAL();
+
+	// ...and now, operational commands.
+	long getPos();
+	long getMark();
+	void run(byte dir, float stepsPerSec);
+	void runRaw(byte dir, unsigned long integerSpeed);
+	void stepClock(byte dir);
+	void move(byte dir, unsigned long numSteps);
+	void goTo(long pos);
+	void goToDir(byte dir, long pos);
+	void goUntil(byte action, byte dir, float stepsPerSec);
+	void goUntilRaw(byte action, byte dir, unsigned long integerSpeed);
+	void releaseSw(byte action, byte dir);
+	void goHome();
+	void goMark();
+	void setMark(long newMark);
+	void setPos(long newPos);
+	void resetPos();
+	void resetDev();
+	void softStop();
+	void hardStop();
+	void softHiZ();
+	void hardHiZ();
+
+
+	private:
+	byte SPIXfer(byte data);
+	long xferParam(unsigned long value, byte bitLen);
+	long paramHandler(byte param, unsigned long value);
+
+	// Support functions for converting from user units to L6470 units
+	unsigned long accCalc(float stepsPerSecPerSec);
+	unsigned long decCalc(float stepsPerSecPerSec);
+	unsigned long minSpdCalc(float stepsPerSec);
+	unsigned long maxSpdCalc(float stepsPerSec);
+	unsigned long FSCalc(float stepsPerSec);
+	unsigned long intSpdCalc(float stepsPerSec);
+	unsigned long spdCalc(float stepsPerSec);
+
+	// Support functions for converting from L6470 to user units
+	float accParse(unsigned long stepsPerSecPerSec);
+	float decParse(unsigned long stepsPerSecPerSec);
+	float minSpdParse(unsigned long stepsPerSec);
+	float maxSpdParse(unsigned long stepsPerSec);
+	float FSParse(unsigned long stepsPerSec);
+	float intSpdParse(unsigned long stepsPerSec);
+	float spdParse(unsigned long stepsPerSec);
+
+	int _CSPin;
+	int _resetPin;
+	int _busyPin;
+	int _position;
+	static int _numBoards;
+	SPIClass *_SPI;
+};
+
+// User constants for public functions.
+
+// dSPIN direction options: functions that accept dir as an argument can be
+//  passed one of these constants. These functions are:
+//    run()
+//    stepClock()
+//    move()
+//    goToDir()
+//    goUntil()
+//    releaseSw()
+#define FWD  0x01
+#define REV  0x00
+
+// dSPIN action options: functions that accept action as an argument can be
+//  passed one of these constants. The contents of ABSPOS will either be
+//  reset or copied to MARK, depending on the value sent. These functions are:
+//    goUntil()
+//    releaseSw()
+#define RESET_ABSPOS  0x00
+#define COPY_ABSPOS   0x08
+
+// configSyncPin() options: the !BUSY/SYNC pin can be configured to be low when
+//  the chip is executing a command, *or* to output a pulse on each full step
+//  clock (with some divisor). These
+#define BUSY_PIN   0x00     // !BUSY/SYNC pin set to !BUSY mode
+#define SYNC_PIN   0x80     // pin set to SYNC mode
+
+// divisors for SYNC pulse outputs
+#define SYNC_FS_2  0x00   // two per full step
+#define SYNC_FS    0x10   // one per full step
+#define SYNC_2FS   0x20   // one per two full steps
+#define SYNC_4FS   0x30   // one per four full steps
+#define SYNC_8FS   0x40   // one per eight full steps
+#define SYNC_16FS  0x50   // one per 16 full steps
+#define SYNC_32FS  0x60   // one per 32 full steps
+#define SYNC_64FS  0x70   // one per 64 full steps
+
+// configStepMode() options: select the microsteps per full step.
+#define STEP_FS    0x00   // one step per full step
+#define STEP_FS_2  0x01   // two microsteps per full step
+#define STEP_FS_4  0x02   // four microsteps per full step
+#define STEP_FS_8  0x03   // etc.
+#define STEP_FS_16 0x04
+#define STEP_FS_32 0x05
+#define STEP_FS_64 0x06
+#define STEP_FS_128 0x07
+
+// PWM Multiplier and divisor options
+#define PWM_MUL_0_625           (0x00)<<10
+#define PWM_MUL_0_75            (0x01)<<10
+#define PWM_MUL_0_875           (0x02)<<10
+#define PWM_MUL_1               (0x03)<<10
+#define PWM_MUL_1_25            (0x04)<<10
+#define PWM_MUL_1_5             (0x05)<<10
+#define PWM_MUL_1_75            (0x06)<<10
+#define PWM_MUL_2               (0x07)<<10
+#define PWM_DIV_1               (0x00)<<13
+#define PWM_DIV_2               (0x01)<<13
+#define PWM_DIV_3               (0x02)<<13
+#define PWM_DIV_4               (0x03)<<13
+#define PWM_DIV_5               (0x04)<<13
+#define PWM_DIV_6               (0x05)<<13
+#define PWM_DIV_7               (0x06)<<13
+
+// Slew rate options, GATECFG1 7:5 = Igate, GATECFG1 4:0 = Tcc,
+// see datasheet tables 11, 34, 35
+#define SR_114V_us              0x0040 | 0x0018  // 8mA | 3125ns = 114V/us
+#define SR_220V_us              0x0060 | 0x000C  // 16mA | 1625ns = 220V/us
+#define SR_400V_us              0x0080 | 0x0007  // 24mA | 1000ns = 400V/us
+#define SR_520V_us              0x00A0 | 0x0006  // 32mA | 875ns = 520V/us
+#define SR_790V_us              0x00C0 | 0x0003  // 64mA | 500ns = 790V/us
+#define SR_980V_us              0x00D0 | 0x0002  // 96mA | 275ns = 980V/us
+
+// Overcurrent bridge shutdown options
+#define OC_SD_DISABLE           0x0000  // Bridges do NOT shutdown on OC detect
+#define OC_SD_ENABLE            0x0080  // Bridges shutdown on OC detect
+
+// Voltage compensation settings. See p 34 of datasheet.
+#define VS_COMP_DISABLE         0x0000  // Disable motor voltage compensation.
+#define VS_COMP_ENABLE          0x0020  // Enable motor voltage compensation.
+
+// External switch input functionality.
+#define SW_HARD_STOP            0x0000 // Default; hard stop motor on switch.
+#define SW_USER                 0x0010 // Tie to the GoUntil and ReleaseSW
+//  commands to provide jog function.
+//  See page 25 of datasheet.
+
+// Clock functionality
+#define INT_16MHZ               0x0000 // Internal 16MHz, no output
+#define INT_16MHZ_OSCOUT_2MHZ   0x0008 // Default; internal 16MHz, 2MHz output
+#define INT_16MHZ_OSCOUT_4MHZ   0x0009 // Internal 16MHz, 4MHz output
+#define INT_16MHZ_OSCOUT_8MHZ   0x000A // Internal 16MHz, 8MHz output
+#define INT_16MHZ_OSCOUT_16MHZ  0x000B // Internal 16MHz, 16MHz output
+#define EXT_8MHZ_XTAL_DRIVE     0x0004 // External 8MHz crystal
+#define EXT_16MHZ_XTAL_DRIVE    0x0005 // External 16MHz crystal
+#define EXT_24MHZ_XTAL_DRIVE    0x0006 // External 24MHz crystal
+#define EXT_32MHZ_XTAL_DRIVE    0x0007 // External 32MHz crystal
+#define EXT_8MHZ_OSCOUT_INVERT  0x000C // External 8MHz crystal, output inverted
+#define EXT_16MHZ_OSCOUT_INVERT 0x000D // External 16MHz crystal, output inverted
+#define EXT_24MHZ_OSCOUT_INVERT 0x000E // External 24MHz crystal, output inverted
+#define EXT_32MHZ_OSCOUT_INVERT 0x000F // External 32MHz crystal, output inverted
+#endif
+

--- a/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibraryCommands.cpp
+++ b/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibraryCommands.cpp
@@ -1,0 +1,249 @@
+#include "powerSTEP01ArduinoLibrary.h"
+
+//commands.ino - Contains high-level command implementations- movement
+//   and configuration commands, for example.
+
+// Realize the "set parameter" function, to write to the various registers in
+//  the dSPIN chip.
+void powerSTEP::setParam(byte param, unsigned long value)
+{
+  param |= SET_PARAM;
+  SPIXfer((byte)param);
+  paramHandler(param, value);
+}
+
+// Realize the "get parameter" function, to read from the various registers in
+//  the dSPIN chip.
+long powerSTEP::getParam(byte param)
+{
+  SPIXfer(param | GET_PARAM);
+  return paramHandler(param, 0);
+}
+
+// Returns the content of the ABS_POS register, which is a signed 22-bit number
+//  indicating the number of steps the motor has traveled from the HOME
+//  position. HOME is defined by zeroing this register, and it is zero on
+//  startup.
+long powerSTEP::getPos()
+{
+  long temp = getParam(ABS_POS);
+
+  // Since ABS_POS is a 22-bit 2's comp value, we need to check bit 21 and, if
+  //  it's set, set all the bits ABOVE 21 in order for the value to maintain
+  //  its appropriate sign.
+  if (temp & 0x00200000) temp |= 0xffc00000;
+  return temp;
+}
+
+// Just like getPos(), but for MARK.
+long powerSTEP::getMark()
+{
+  long temp = getParam(MARK);
+
+  // Since ABS_POS is a 22-bit 2's comp value, we need to check bit 21 and, if
+  //  it's set, set all the bits ABOVE 21 in order for the value to maintain
+  //  its appropriate sign.
+  if (temp & 0x00200000) temp |= 0xffC00000;
+  return temp;
+}
+
+// RUN sets the motor spinning in a direction (defined by the constants
+//  FWD and REV). Maximum speed and minimum speed are defined
+//  by the MAX_SPEED and MIN_SPEED registers; exceeding the FS_SPD value
+//  will switch the device into full-step mode.
+// The spdCalc() function is provided to convert steps/s values into
+//  appropriate integer values for this function.
+void powerSTEP::run(byte dir, float stepsPerSec)
+{
+
+  unsigned long integerSpeed = spdCalc(stepsPerSec);
+  runRaw(dir, integerSpeed);
+}
+void powerSTEP::runRaw(byte dir, unsigned long integerSpeed) {
+	SPIXfer(RUN | dir);
+  if (integerSpeed > 0xFFFFF) integerSpeed = 0xFFFFF;
+
+  // Now we need to push this value out to the dSPIN. The 32-bit value is
+  //  stored in memory in little-endian format, but the dSPIN expects a
+  //  big-endian output, so we need to reverse the byte-order of the
+  //  data as we're sending it out. Note that only 3 of the 4 bytes are
+  //  valid here.
+
+  // We begin by pointing bytePointer at the first byte in integerSpeed.
+  byte* bytePointer = (byte*)&integerSpeed;
+  // Next, we'll iterate through a for loop, indexing across the bytes in
+  //  integerSpeed starting with byte 2 and ending with byte 0.
+  for (int8_t i = 2; i >= 0; i--)
+  {
+	  SPIXfer(bytePointer[i]);
+  }
+}
+// STEP_CLOCK puts the device in external step clocking mode. When active,
+//  pin 25, STCK, becomes the step clock for the device, and steps it in
+//  the direction (set by the FWD and REV constants) imposed by the call
+//  of this function. Motion commands (RUN, MOVE, etc) will cause the device
+//  to exit step clocking mode.
+void powerSTEP::stepClock(byte dir)
+{
+  SPIXfer(STEP_CLOCK | dir);
+}
+
+// MOVE will send the motor numStep full steps in the
+//  direction imposed by dir (FWD or REV constants may be used). The motor
+//  will accelerate according the acceleration and deceleration curves, and
+//  will run at MAX_SPEED. Stepping mode will adhere to FS_SPD value, as well.
+void powerSTEP::move(byte dir, unsigned long numSteps)
+{
+  SPIXfer(MOVE | dir);
+  if (numSteps > 0x3FFFFF) numSteps = 0x3FFFFF;
+  // See run() for an explanation of what's going on here.
+  byte* bytePointer = (byte*)&numSteps;
+  for (int8_t i = 2; i >= 0; i--)
+  {
+    SPIXfer(bytePointer[i]);
+  }
+}
+
+// GOTO operates much like MOVE, except it produces absolute motion instead
+//  of relative motion. The motor will be moved to the indicated position
+//  in the shortest possible fashion.
+void powerSTEP::goTo(long pos)
+{
+  SPIXfer(GOTO);
+  if (pos > 0x3FFFFF) pos = 0x3FFFFF;
+  // See run() for an explanation of what's going on here.
+  byte* bytePointer = (byte*)&pos;
+  for (int8_t i = 2; i >= 0; i--)
+  {
+    SPIXfer(bytePointer[i]);
+  }
+}
+
+// Same as GOTO, but with user constrained rotational direction.
+void powerSTEP::goToDir(byte dir, long pos)
+{
+  SPIXfer(GOTO_DIR | dir);
+  if (pos > 0x3FFFFF) pos = 0x3FFFFF;
+  // See run() for an explanation of what's going on here.
+  byte* bytePointer = (byte*)&pos;
+  for (int8_t i = 2; i >= 0; i--)
+  {
+    SPIXfer(bytePointer[i]);
+  }
+}
+
+// GoUntil will set the motor running with direction dir (REV or
+//  FWD) until a falling edge is detected on the SW pin. Depending
+//  on bit SW_MODE in CONFIG, either a hard stop or a soft stop is
+//  performed at the falling edge, and depending on the value of
+//  act (either RESET or COPY) the value in the ABS_POS register is
+//  either RESET to 0 or COPY-ed into the MARK register.
+void powerSTEP::goUntil(byte action, byte dir, float stepsPerSec)
+{
+  unsigned long integerSpeed = spdCalc(stepsPerSec);
+  goUntilRaw(action, dir, integerSpeed);
+}
+
+void powerSTEP::goUntilRaw(byte action, byte dir, unsigned long integerSpeed)
+{
+	SPIXfer(GO_UNTIL | action | dir);
+
+	if (integerSpeed > 0x3FFFFF) integerSpeed = 0x3FFFFF;
+	// See run() for an explanation of what's going on here.
+	byte* bytePointer = (byte*)&integerSpeed;
+	for (int8_t i = 2; i >= 0; i--)
+	{
+		SPIXfer(bytePointer[i]);
+	}
+}
+
+// Similar in nature to GoUntil, ReleaseSW produces motion at the
+//  higher of two speeds: the value in MIN_SPEED or 5 steps/s.
+//  The motor continues to run at this speed until a rising edge
+//  is detected on the switch input, then a hard stop is performed
+//  and the ABS_POS register is either COPY-ed into MARK or RESET to
+//  0, depending on whether RESET or COPY was passed to the function
+//  for act.
+void powerSTEP::releaseSw(byte action, byte dir)
+{
+  SPIXfer(RELEASE_SW | action | dir);
+}
+
+// GoHome is equivalent to GoTo(0), but requires less time to send.
+//  Note that no direction is provided; motion occurs through shortest
+//  path. If a direction is required, use GoTo_DIR().
+void powerSTEP::goHome()
+{
+  SPIXfer(GO_HOME);
+}
+
+// GoMark is equivalent to GoTo(MARK), but requires less time to send.
+//  Note that no direction is provided; motion occurs through shortest
+//  path. If a direction is required, use GoTo_DIR().
+void powerSTEP::goMark()
+{
+  SPIXfer(GO_MARK);
+}
+
+// setMark() and setHome() allow the user to define new MARK or
+//  ABS_POS values.
+void powerSTEP::setMark(long newMark)
+{
+  setParam(MARK, newMark);
+}
+
+void powerSTEP::setPos(long newPos)
+{
+  setParam(ABS_POS, newPos);
+}
+
+// Sets the ABS_POS register to 0, effectively declaring the current
+//  position to be "HOME".
+void powerSTEP::resetPos()
+{
+  SPIXfer(RESET_POS);
+}
+
+// Reset device to power up conditions. Equivalent to toggling the STBY
+//  pin or cycling power.
+void powerSTEP::resetDev()
+{
+  SPIXfer(RESET_DEVICE);
+}
+
+// Bring the motor to a halt using the deceleration curve.
+void powerSTEP::softStop()
+{
+  SPIXfer(SOFT_STOP);
+}
+
+// Stop the motor with infinite deceleration.
+void powerSTEP::hardStop()
+{
+  SPIXfer(HARD_STOP);
+}
+
+// Decelerate the motor and put the bridges in Hi-Z state.
+void powerSTEP::softHiZ()
+{
+  SPIXfer(SOFT_HIZ);
+}
+
+// Put the bridges in Hi-Z state immediately with no deceleration.
+void powerSTEP::hardHiZ()
+{
+  SPIXfer(HARD_HIZ);
+}
+
+// Fetch and return the 16-bit value in the STATUS register. Resets
+//  any warning flags and exits any error states. Using GetParam()
+//  to read STATUS does not clear these values.
+int powerSTEP::getStatus()
+{
+  int temp = 0;
+  byte* bytePointer = (byte*)&temp;
+  SPIXfer(GET_STATUS);
+  bytePointer[1] = SPIXfer(0);
+  bytePointer[0] = SPIXfer(0);
+  return temp;
+}

--- a/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibraryCommands.cpp
+++ b/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibraryCommands.cpp
@@ -242,7 +242,7 @@ int powerSTEP::getStatus()
 {
   int temp = 0;
   byte* bytePointer = (byte*)&temp;
-  SPIXfer(GET_STATUS);
+  SPIXfer(GET_STATUS);  
   bytePointer[1] = SPIXfer(0);
   bytePointer[0] = SPIXfer(0);
   return temp;

--- a/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibraryConfig.cpp
+++ b/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibraryConfig.cpp
@@ -1,0 +1,420 @@
+#include "powerSTEP01ArduinoLibrary.h"
+
+// Setup the SYNC/BUSY pin to be either SYNC or BUSY, and to a desired
+//  ticks per step level.
+void powerSTEP::configSyncPin(byte pinFunc, byte syncSteps)
+{
+  // Only some of the bits in this register are of interest to us; we need to
+  //  clear those bits. It happens that they are the upper four.
+  byte syncPinConfig = (byte)getParam(STEP_MODE);
+  syncPinConfig &= 0x0F;
+
+  // Now, let's OR in the arguments. We're going to mask the incoming
+  //  data to avoid touching any bits that aren't appropriate. See datasheet
+  //  for more info about which bits we're touching.
+  syncPinConfig |= ((pinFunc & 0x80) | (syncSteps & 0x70));
+
+  // Now we should be able to send that byte right back to the dSPIN- it
+  //  won't corrupt the other bits, and the changes are made.
+  setParam(STEP_MODE, (unsigned long)syncPinConfig);
+}
+
+// The dSPIN chip supports microstepping for a smoother ride. This function
+//  provides an easy front end for changing the microstepping mode.
+void powerSTEP::configStepMode(byte stepMode)
+{
+
+  // Only some of these bits are useful (the lower three). We'll extract the
+  //  current contents, clear those three bits, then set them accordingly.
+  byte stepModeConfig = (byte)getParam(STEP_MODE);
+  stepModeConfig &= 0xF8;
+
+  // Now we can OR in the new bit settings. Mask the argument so we don't
+  //  accidentally the other bits, if the user sends us a non-legit value.
+  stepModeConfig |= (stepMode&0x07);
+
+  // Now push the change to the chip.
+  setParam(STEP_MODE, (unsigned long)stepModeConfig);
+}
+
+byte powerSTEP::getStepMode() {
+  return (byte)(getParam(STEP_MODE) & 0x07);
+}
+void powerSTEP::voltageMode(byte stepMode) {
+	  // Only some of these bits are useful (the lower three). We'll extract the
+	  //  current contents, clear those three bits, then set them accordingly.
+	  byte stepModeConfig = (byte)getParam(STEP_MODE);
+	  stepModeConfig &= 0xF0;
+
+	  // Now we can OR in the new bit settings. Mask the argument so we don't
+	  //  accidentally the other bits, if the user sends us a non-legit value.
+	  stepModeConfig |= (stepMode&0x07);
+
+	  // Now push the change to the chip.
+	  setParam(STEP_MODE, (unsigned long)stepModeConfig);
+}
+void powerSTEP::currentMode(byte stepMode) {
+	  // Only some of these bits are useful (the lower three). We'll extract the
+	  //  current contents, clear those three bits, then set them accordingly.
+	  byte stepModeConfig = (byte)getParam(STEP_MODE);
+	  stepModeConfig &= 0xF8;
+	  stepModeConfig |= 0x8;
+	  // Now we can OR in the new bit settings. Mask the argument so we don't
+	  //  accidentally the other bits, if the user sends us a non-legit value.
+	  stepModeConfig |= (stepMode&0x07);
+
+	  // Now push the change to the chip.
+	  setParam(STEP_MODE, (unsigned long)stepModeConfig);
+}
+// This is the maximum speed the dSPIN will attempt to produce.
+void powerSTEP::setMaxSpeed(float stepsPerSecond)
+{
+  // We need to convert the floating point stepsPerSecond into a value that
+  //  the dSPIN can understand. Fortunately, we have a function to do that.
+  unsigned long integerSpeed = maxSpdCalc(stepsPerSecond);
+
+  setMaxSpeedRaw(integerSpeed);
+}
+void powerSTEP::setMaxSpeedRaw(unsigned long integerSpeed)
+{
+	// Now, we can set that paramter.
+	setParam(MAX_SPEED, integerSpeed);
+}
+
+float powerSTEP::getMaxSpeed()
+{
+  return maxSpdParse(getMaxSpeedRaw());
+}
+unsigned long powerSTEP::getMaxSpeedRaw()
+{
+	return getParam(MAX_SPEED);
+}
+
+// Set the minimum speed allowable in the system. This is the speed a motion
+//  starts with; it will then ramp up to the designated speed or the max
+//  speed, using the acceleration profile.
+void powerSTEP::setMinSpeed(float stepsPerSecond)
+{
+  // We need to convert the floating point stepsPerSecond into a value that
+  //  the dSPIN can understand. Fortunately, we have a function to do that.
+  unsigned long integerSpeed = minSpdCalc(stepsPerSecond);
+
+  setMinSpeedRaw(integerSpeed);
+}
+void powerSTEP::setMinSpeedRaw(unsigned long integerSpeed)
+{
+	// MIN_SPEED also contains the LSPD_OPT flag, so we need to protect that.
+	unsigned long temp = getParam(MIN_SPEED) & 0x00001000;
+
+	// Now, we can set that paramter.
+	setParam(MIN_SPEED, integerSpeed | temp);
+}
+
+float powerSTEP::getMinSpeed()
+{
+  return minSpdParse(getMinSpeedRaw());
+}
+unsigned long powerSTEP::getMinSpeedRaw()
+{
+	return getParam(MIN_SPEED);
+}
+// Above this threshold, the dSPIN will cease microstepping and go to full-step
+//  mode.
+void powerSTEP::setFullSpeed(float stepsPerSecond)
+{
+  unsigned long integerSpeed = FSCalc(stepsPerSecond);
+  setFullSpeedRaw(integerSpeed);
+}
+void powerSTEP::setFullSpeedRaw(unsigned long integerSpeed)
+{
+	setParam(FS_SPD, integerSpeed);
+}
+
+float powerSTEP::getFullSpeed()
+{
+  return FSParse(getFullSpeedRaw());
+}
+unsigned long powerSTEP::getFullSpeedRaw()
+{
+	return getParam(FS_SPD);
+}
+
+// Set the acceleration rate, in steps per second per second. This value is
+//  converted to a dSPIN friendly value. Any value larger than 29802 will
+//  disable acceleration, putting the chip in "infinite" acceleration mode.
+void powerSTEP::setAcc(float stepsPerSecondPerSecond)
+{
+  unsigned long integerAcc = accCalc(stepsPerSecondPerSecond);
+  setAccRaw(integerAcc);
+}
+void powerSTEP::setAccRaw(unsigned long integerAcc)
+{
+	setParam(ACC, integerAcc);
+}
+
+float powerSTEP::getAcc()
+{
+  return accParse(getAccRaw());
+}
+
+unsigned long powerSTEP::getAccRaw()
+{
+	return getParam(ACC);
+}
+
+// Same rules as setAcc().
+void powerSTEP::setDec(float stepsPerSecondPerSecond)
+{
+  unsigned long integerDec = decCalc(stepsPerSecondPerSecond);
+  setDecRaw(integerDec);
+}
+void powerSTEP::setDecRaw(unsigned long integerDec)
+{
+	setParam(DECEL, integerDec);
+}
+
+float powerSTEP::getDec()
+{
+  return decParse(getDecRaw());
+}
+unsigned long powerSTEP::getDecRaw()
+{
+	return getParam(DECEL);
+}
+
+void powerSTEP::setOCThreshold(byte threshold)
+{
+  setParam(OCD_TH, 0x1F & threshold);
+}
+
+byte powerSTEP::getOCThreshold()
+{
+  return (byte) (getParam(OCD_TH) & 0x1F);
+}
+
+// The next few functions are all breakouts for individual options within the
+//  single register CONFIG. We'll read CONFIG, blank some bits, then OR in the
+//  new value.
+
+// This is a multiplier/divider setup for the PWM frequency when microstepping.
+//  Divisors of 1-7 are available; multipliers of .625-2 are available. See
+//  datasheet for more details; it's not clear what the frequency being
+//  multiplied/divided here is, but it is clearly *not* the actual clock freq.
+void powerSTEP::setPWMFreq(int divisor, int multiplier)
+{
+  unsigned long configVal = getParam(CONFIG);
+
+  // The divisor is set by config 15:13, so mask 0xE000 to clear them.
+  configVal &= ~(0xE000);
+  // The multiplier is set by config 12:10; mask is 0x1C00
+  configVal &= ~(0x1C00);
+  // Now we can OR in the masked-out versions of the values passed in.
+  configVal |= ((0xE000&divisor)|(0x1C00&multiplier));
+  setParam(CONFIG, configVal);
+}
+
+int powerSTEP::getPWMFreqDivisor()
+{
+  return (int) (getParam(CONFIG) & 0xE000);
+}
+
+int powerSTEP::getPWMFreqMultiplier()
+{
+  return (int) (getParam(CONFIG) & 0x1C00);
+}
+
+// Slew rate of the output in V/us. Can be 114, 220, 400, 520, 790, 980.
+void powerSTEP::setSlewRate(int slewRate)
+{
+  unsigned long configVal = getParam(GATECFG1);
+
+  // These bits live in GATECFG1 7:0, so the mask is 0x00FF.
+  configVal &= ~(0x00FF);
+  //Now, OR in the masked incoming value.
+  configVal |= (0x00FF&slewRate);
+  setParam(GATECFG1, configVal);
+}
+
+int powerSTEP::getSlewRate()
+{
+  return (int) (getParam(CONFIG) & 0x0300);
+}
+
+// Single bit- do we shutdown the drivers on overcurrent or not?
+void powerSTEP::setOCShutdown(int OCShutdown)
+{
+  unsigned long configVal = getParam(CONFIG);
+  // This bit is CONFIG 7, mask is 0x0080
+  configVal &= ~(0x0080);
+  //Now, OR in the masked incoming value.
+  configVal |= (0x0080&OCShutdown);
+  setParam(CONFIG, configVal);
+}
+
+int powerSTEP::getOCShutdown()
+{
+  return (int) (getParam(CONFIG) & 0x0080);
+}
+
+// Enable motor voltage compensation? Not at all straightforward- check out
+//  p34 of the datasheet.
+void powerSTEP::setVoltageComp(int vsCompMode)
+{
+  unsigned long configVal = getParam(CONFIG);
+  // This bit is CONFIG 5, mask is 0x0020
+  configVal &= ~(0x0020);
+  //Now, OR in the masked incoming value.
+  configVal |= (0x0020&vsCompMode);
+  setParam(CONFIG, configVal);
+}
+
+int powerSTEP::getVoltageComp()
+{
+  return (int) (getParam(CONFIG) & 0x0020);
+}
+
+// The switch input can either hard-stop the driver _or_ activate an interrupt.
+//  This bit allows you to select what it does.
+void powerSTEP::setSwitchMode(int switchMode)
+{
+  unsigned long configVal = getParam(CONFIG);
+  // This bit is CONFIG 4, mask is 0x0010
+  configVal &= ~(0x0010);
+  //Now, OR in the masked incoming value.
+  configVal |= (0x0010 & switchMode);
+  setParam(CONFIG, configVal);
+}
+
+int powerSTEP::getSwitchMode()
+{
+  return (int) (getParam(CONFIG) & 0x0010);
+}
+
+// There are a number of clock options for this chip- it can be configured to
+//  accept a clock, drive a crystal or resonator, and pass or not pass the
+//  clock signal downstream. Theoretically, you can use pretty much any
+//  frequency you want to drive it; practically, this library assumes it's
+//  being driven at 16MHz. Also, the device will use these bits to set the
+//  math used to figure out steps per second and stuff like that.
+void powerSTEP::setOscMode(int oscillatorMode)
+{
+  unsigned long configVal = getParam(CONFIG);
+  // These bits are CONFIG 3:0, mask is 0x000F
+  configVal &= ~(0x000F);
+  //Now, OR in the masked incoming value.
+  configVal |= (0x000F&oscillatorMode);
+  setParam(CONFIG, configVal);
+}
+
+int powerSTEP::getOscMode()
+{
+  return (int) (getParam(CONFIG) & 0x000F);
+}
+
+// The KVAL registers are...weird. I don't entirely understand how they differ
+//  from the microstepping, but if you have trouble getting the motor to run,
+//  tweaking KVAL has proven effective in the past. There's a separate register
+//  for each case: running, static, accelerating, and decelerating.
+
+void powerSTEP::setAccKVAL(byte kvalInput)
+{
+  setParam(KVAL_ACC, kvalInput);
+}
+
+byte powerSTEP::getAccKVAL()
+{
+  return (byte) getParam(KVAL_ACC);
+}
+
+void powerSTEP::setDecKVAL(byte kvalInput)
+{
+  setParam(KVAL_DEC, kvalInput);
+}
+
+byte powerSTEP::getDecKVAL()
+{
+  return (byte) getParam(KVAL_DEC);
+}
+
+void powerSTEP::setRunKVAL(byte kvalInput)
+{
+  setParam(KVAL_RUN, kvalInput);
+}
+
+byte powerSTEP::getRunKVAL()
+{
+  return (byte) getParam(KVAL_RUN);
+}
+
+void powerSTEP::setHoldKVAL(byte kvalInput)
+{
+  setParam(KVAL_HOLD, kvalInput);
+}
+
+byte powerSTEP::getHoldKVAL()
+{
+  return (byte) getParam(KVAL_HOLD);
+}
+
+
+// The KVAL registers are...weird. I don't entirely understand how they differ
+//  from the microstepping, but if you have trouble getting the motor to run,
+//  tweaking KVAL has proven effective in the past. There's a separate register
+//  for each case: running, static, accelerating, and decelerating.
+
+void powerSTEP::setAccTVAL(byte tvalInput)
+{
+	setParam(TVAL_ACC, tvalInput);
+}
+
+byte powerSTEP::getAccTVAL()
+{
+	return (byte) getParam(TVAL_ACC);
+}
+
+void powerSTEP::setDecTVAL(byte tvalInput)
+{
+	setParam(TVAL_DEC, tvalInput);
+}
+
+byte powerSTEP::getDecTVAL()
+{
+	return (byte) getParam(TVAL_DEC);
+}
+
+void powerSTEP::setRunTVAL(byte tvalInput)
+{
+	setParam(TVAL_RUN, tvalInput);
+}
+
+byte powerSTEP::getRunTVAL()
+{
+	return (byte) getParam(TVAL_RUN);
+}
+
+void powerSTEP::setHoldTVAL(byte tvalInput)
+{
+	setParam(TVAL_HOLD, tvalInput);
+}
+
+byte powerSTEP::getHoldTVAL()
+{
+	return (byte) getParam(TVAL_HOLD);
+}
+
+// Enable or disable the low-speed optimization option. With LSPD_OPT enabled,
+//  motion starts from 0 instead of MIN_SPEED and low-speed optimization keeps
+//  the driving sine wave prettier than normal until MIN_SPEED is reached.
+void powerSTEP::setLoSpdOpt(boolean enable)
+{
+  unsigned long temp = getParam(MIN_SPEED);
+  if (enable) temp |= 0x00001000; // Set the LSPD_OPT bit
+  else        temp &= 0xffffefff; // Clear the LSPD_OPT bit
+  setParam(MIN_SPEED, temp);
+}
+
+boolean powerSTEP::getLoSpdOpt()
+{
+  return (boolean) ((getParam(MIN_SPEED) & 0x00001000) != 0);
+}
+

--- a/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibrarySupport.cpp
+++ b/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibrarySupport.cpp
@@ -1,0 +1,336 @@
+#include "powerSTEP01ArduinoLibrary.h"
+#include <SPI.h>
+
+// powerSTEPSupport.cpp - Contains utility functions for converting real-world 
+//  units (eg, steps/s) to values usable by the dsPIN controller. These are all
+//  private members of class powerSTEP.
+
+// The value in the ACC register is [(steps/s/s)*(tick^2)]/(2^-40) where tick is 
+//  250ns (datasheet value)- 0x08A on boot.
+// Multiply desired steps/s/s by .137438 to get an appropriate value for this register.
+// This is a 12-bit value, so we need to make sure the value is at or below 0xFFF.
+unsigned long powerSTEP::accCalc(float stepsPerSecPerSec)
+{
+  float temp = stepsPerSecPerSec * 0.137438;
+  if( (unsigned long) long(temp) > 0x00000FFF) return 0x00000FFF;
+  else return (unsigned long) long(temp);
+}
+
+
+float powerSTEP::accParse(unsigned long stepsPerSecPerSec)
+{
+    return (float) (stepsPerSecPerSec & 0x00000FFF) / 0.137438;
+}
+
+// The calculation for DEC is the same as for ACC. Value is 0x08A on boot.
+// This is a 12-bit value, so we need to make sure the value is at or below 0xFFF.
+unsigned long powerSTEP::decCalc(float stepsPerSecPerSec)
+{
+  float temp = stepsPerSecPerSec * 0.137438;
+  if( (unsigned long) long(temp) > 0x00000FFF) return 0x00000FFF;
+  else return (unsigned long) long(temp);
+}
+
+float powerSTEP::decParse(unsigned long stepsPerSecPerSec)
+{
+    return (float) (stepsPerSecPerSec & 0x00000FFF) / 0.137438;
+}
+
+// The value in the MAX_SPD register is [(steps/s)*(tick)]/(2^-18) where tick is 
+//  250ns (datasheet value)- 0x041 on boot.
+// Multiply desired steps/s by .065536 to get an appropriate value for this register
+// This is a 10-bit value, so we need to make sure it remains at or below 0x3FF
+unsigned long powerSTEP::maxSpdCalc(float stepsPerSec)
+{
+  unsigned long temp = ceil(stepsPerSec * .065536);
+  if( temp > 0x000003FF) return 0x000003FF;
+  else return temp;
+}
+
+
+float powerSTEP::maxSpdParse(unsigned long stepsPerSec)
+{
+    return (float) (stepsPerSec & 0x000003FF) / 0.065536;
+}
+
+// The value in the MIN_SPD register is [(steps/s)*(tick)]/(2^-24) where tick is 
+//  250ns (datasheet value)- 0x000 on boot.
+// Multiply desired steps/s by 4.1943 to get an appropriate value for this register
+// This is a 12-bit value, so we need to make sure the value is at or below 0xFFF.
+unsigned long powerSTEP::minSpdCalc(float stepsPerSec)
+{
+  float temp = stepsPerSec / 0.238;
+  if( (unsigned long) long(temp) > 0x00000FFF) return 0x00000FFF;
+  else return (unsigned long) long(temp);
+}
+
+float powerSTEP::minSpdParse(unsigned long stepsPerSec)
+{
+    return (float) ((stepsPerSec & 0x00000FFF) * 0.238);
+}
+
+// The value in the FS_SPD register is ([(steps/s)*(tick)]/(2^-18))-0.5 where tick is 
+//  250ns (datasheet value)- 0x027 on boot.
+// Multiply desired steps/s by .065536 and subtract .5 to get an appropriate value for this register
+// This is a 10-bit value, so we need to make sure the value is at or below 0x3FF.
+unsigned long powerSTEP::FSCalc(float stepsPerSec)
+{
+  float temp = (stepsPerSec * .065536)-.5;
+  if( (unsigned long) long(temp) > 0x000003FF) return 0x000003FF;
+  else return (unsigned long) long(temp);
+}
+
+float powerSTEP::FSParse(unsigned long stepsPerSec)
+{
+    return (((float) (stepsPerSec & 0x000003FF)) + 0.5) / 0.065536;
+}
+
+// The value in the INT_SPD register is [(steps/s)*(tick)]/(2^-24) where tick is 
+//  250ns (datasheet value)- 0x408 on boot.
+// Multiply desired steps/s by 4.1943 to get an appropriate value for this register
+// This is a 14-bit value, so we need to make sure the value is at or below 0x3FFF.
+unsigned long powerSTEP::intSpdCalc(float stepsPerSec)
+{
+  float temp = stepsPerSec * 4.1943;
+  if( (unsigned long) long(temp) > 0x00003FFF) return 0x00003FFF;
+  else return (unsigned long) long(temp);
+}
+
+float powerSTEP::intSpdParse(unsigned long stepsPerSec)
+{
+    return (float) (stepsPerSec & 0x00003FFF) / 4.1943;
+}
+
+// When issuing RUN command, the 20-bit speed is [(steps/s)*(tick)]/(2^-28) where tick is 
+//  250ns (datasheet value).
+// Multiply desired steps/s by 67.106 to get an appropriate value for this register
+// This is a 20-bit value, so we need to make sure the value is at or below 0xFFFFF.
+unsigned long powerSTEP::spdCalc(float stepsPerSec)
+{
+  unsigned long temp = stepsPerSec * 67.106;
+  if( temp > 0x000FFFFF) return 0x000FFFFF;
+  else return temp;
+}
+
+float powerSTEP::spdParse(unsigned long stepsPerSec)
+{
+    return (float) (stepsPerSec & 0x000FFFFF) / 67.106;
+}
+
+// Much of the functionality between "get parameter" and "set parameter" is
+//  very similar, so we deal with that by putting all of it in one function
+//  here to save memory space and simplify the program.
+long powerSTEP::paramHandler(byte param, unsigned long value)
+{
+  long retVal = 0;   // This is a temp for the value to return.
+  
+  // This switch structure handles the appropriate action for each register.
+  //  This is necessary since not all registers are of the same length, either
+  //  bit-wise or byte-wise, so we want to make sure we mask out any spurious
+  //  bits and do the right number of transfers. That is handled by the xferParam()
+  //  function, in most cases, but for 1-byte or smaller transfers, we call
+  //  SPIXfer() directly.
+  switch (param)
+  {
+    // ABS_POS is the current absolute offset from home. It is a 22 bit number expressed
+    //  in two's complement. At power up, this value is 0. It cannot be written when
+    //  the motor is running, but at any other time, it can be updated to change the
+    //  interpreted position of the motor.
+    case ABS_POS:
+      retVal = xferParam(value, 22);
+      break;
+    // EL_POS is the current electrical position in the step generation cycle. It can
+    //  be set when the motor is not in motion. Value is 0 on power up.
+    case EL_POS:
+      retVal = xferParam(value, 9);
+      break;
+    // MARK is a second position other than 0 that the motor can be told to go to. As
+    //  with ABS_POS, it is 22-bit two's complement. Value is 0 on power up.
+    case MARK:
+      retVal = xferParam(value, 22);
+      break;
+    // SPEED contains information about the current speed. It is read-only. It does 
+    //  NOT provide direction information.
+    case SPEED:
+      retVal = xferParam(0, 20);
+      break; 
+    // ACC and DEC set the acceleration and deceleration rates. Set ACC to 0xFFF 
+    //  to get infinite acceleration/decelaeration- there is no way to get infinite
+    //  deceleration w/o infinite acceleration (except the HARD STOP command).
+    //  Cannot be written while motor is running. Both default to 0x08A on power up.
+    // AccCalc() and DecCalc() functions exist to convert steps/s/s values into
+    //  12-bit values for these two registers.
+    case ACC: 
+      retVal = xferParam(value, 12);
+      break;
+    case DECEL: 
+      retVal = xferParam(value, 12);
+      break;
+    // MAX_SPEED is just what it says- any command which attempts to set the speed
+    //  of the motor above this value will simply cause the motor to turn at this
+    //  speed. Value is 0x041 on power up.
+    // MaxSpdCalc() function exists to convert steps/s value into a 10-bit value
+    //  for this register.
+    case MAX_SPEED:
+      retVal = xferParam(value, 10);
+      break;
+    // MIN_SPEED controls two things- the activation of the low-speed optimization
+    //  feature and the lowest speed the motor will be allowed to operate at. LSPD_OPT
+    //  is the 13th bit, and when it is set, the minimum allowed speed is automatically
+    //  set to zero. This value is 0 on startup.
+    // MinSpdCalc() function exists to convert steps/s value into a 12-bit value for this
+    //  register. SetLSPDOpt() function exists to enable/disable the optimization feature.
+    case MIN_SPEED: 
+      retVal = xferParam(value, 13);
+      break;
+    // FS_SPD register contains a threshold value above which microstepping is disabled
+    //  and the dSPIN operates in full-step mode. Defaults to 0x027 on power up.
+    // FSCalc() function exists to convert steps/s value into 10-bit integer for this
+    //  register.
+    case FS_SPD:
+      retVal = xferParam(value, 10);
+      break;
+    // KVAL is the maximum voltage of the PWM outputs. These 8-bit values are ratiometric
+    //  representations: 255 for full output voltage, 128 for half, etc. Default is 0x29.
+    // The implications of different KVAL settings is too complex to dig into here, but
+    //  it will usually work to max the value for RUN, ACC, and DEC. Maxing the value for
+    //  HOLD may result in excessive power dissipation when the motor is not running.
+    case KVAL_HOLD:
+      retVal = xferParam(value, 8);
+      break;
+    case KVAL_RUN:
+      retVal = xferParam(value, 8);
+      break;
+    case KVAL_ACC:
+      retVal = xferParam(value, 8);
+      break;
+    case KVAL_DEC:
+      retVal = xferParam(value, 8);
+      break;
+    // INT_SPD, ST_SLP, FN_SLP_ACC and FN_SLP_DEC are all related to the back EMF
+    //  compensation functionality. Please see the datasheet for details of this
+    //  function- it is too complex to discuss here. Default values seem to work
+    //  well enough.
+    case INT_SPD:
+      retVal = xferParam(value, 14);
+      break;
+    case ST_SLP: 
+      retVal = xferParam(value, 8);
+      break;
+    case FN_SLP_ACC: 
+      retVal = xferParam(value, 8);
+      break;
+    case FN_SLP_DEC: 
+      retVal = xferParam(value, 8);
+      break;
+    // K_THERM is motor winding thermal drift compensation. Please see the datasheet
+    //  for full details on operation- the default value should be okay for most users.
+    case K_THERM: 
+      value &= 0x0F;
+      retVal = xferParam(value, 8);
+      break;
+    // ADC_OUT is a read-only register containing the result of the ADC measurements.
+    //  This is less useful than it sounds; see the datasheet for more information.
+    case ADC_OUT:
+      retVal = xferParam(value, 8);
+      break;
+    // Set the overcurrent threshold. Ranges from 375mA to 6A in steps of 375mA.
+    //  A set of defined constants is provided for the user's convenience. Default
+    //  value is 3.375A- 0x08. This is a 4-bit value.
+    case OCD_TH: 
+      value &= 0x1F;
+      retVal = xferParam(value, 8);
+      break;
+    // Stall current threshold. Defaults to 0x40, or 2.03A. Value is from 31.25mA to
+    //  4A in 31.25mA steps. This is a 7-bit value.
+    case STALL_TH: 
+      value &= 0x1F;
+      retVal = xferParam(value, 8);
+      break;
+    // STEP_MODE controls the microstepping settings, as well as the generation of an
+    //  output signal from the dSPIN. Bits 2:0 control the number of microsteps per
+    //  step the part will generate. Bit 7 controls whether the BUSY/SYNC pin outputs
+    //  a BUSY signal or a step synchronization signal. Bits 6:4 control the frequency
+    //  of the output signal relative to the full-step frequency; see datasheet for
+    //  that relationship as it is too complex to reproduce here.
+    // Most likely, only the microsteps per step value will be needed; there is a set
+    //  of constants provided for ease of use of these values.
+    case STEP_MODE:
+      retVal = xferParam(value, 8);
+      break;
+    // ALARM_EN controls which alarms will cause the FLAG pin to fall. A set of constants
+    //  is provided to make this easy to interpret. By default, ALL alarms will trigger the
+    //  FLAG pin.
+    case ALARM_EN: 
+      retVal = xferParam(value, 8);
+      break;
+    // GATECFG1 controls driver transistor gate discharging and clock source monitoring
+    case GATECFG1:
+      retVal = xferParam(value, 16);
+      break;
+    // GATECFG2 controls driver dead time and blanking
+    case GATECFG2:
+      retVal = xferParam(value, 8);
+      break;
+    // CONFIG contains some assorted configuration bits and fields. A fairly comprehensive
+    //  set of reasonably self-explanatory constants is provided, but users should refer
+    //  to the datasheet before modifying the contents of this register to be certain they
+    //  understand the implications of their modifications. Value on boot is 0x2E88; this
+    //  can be a useful way to verify proper start up and operation of the dSPIN chip.
+    case CONFIG: 
+      retVal = xferParam(value, 16);
+      break;
+    // STATUS contains read-only information about the current condition of the chip. A
+    //  comprehensive set of constants for masking and testing this register is provided, but
+    //  users should refer to the datasheet to ensure that they fully understand each one of
+    //  the bits in the register.
+    case STATUS:  // STATUS is a read-only register
+      retVal = xferParam(0, 16);;
+      break;
+    default:
+      SPIXfer((byte)value);
+      break;
+  }
+  return retVal;
+}
+
+// Generalization of the subsections of the register read/write functionality.
+//  We want the end user to just write the value without worrying about length,
+//  so we pass a bit length parameter from the calling function.
+long powerSTEP::xferParam(unsigned long value, byte bitLen)
+{
+  byte byteLen = bitLen/8;      // How many BYTES do we have?
+  if (bitLen%8 > 0) byteLen++;  // Make sure not to lose any partial byte values.
+  
+  byte temp;
+
+  unsigned long retVal = 0; 
+
+  for (int i = 0; i < byteLen; i++)
+  {
+    retVal = retVal << 8;
+    temp = SPIXfer((byte)(value>>((byteLen-i-1)*8)));
+    retVal |= temp;
+  }
+
+  unsigned long mask = 0xffffffff >> (32-bitLen);
+  return retVal & mask;
+}
+
+byte powerSTEP::SPIXfer(byte data)
+{
+  byte dataPacket[_numBoards];
+  int i;
+  for (i=0; i < _numBoards; i++)
+  {
+    dataPacket[i] = 0;
+  }
+  dataPacket[_position] = data;
+  digitalWrite(_CSPin, LOW);
+  _SPI->beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE3));
+  _SPI->transfer(dataPacket, _numBoards);
+  _SPI->endTransaction();
+  digitalWrite(_CSPin, HIGH);
+  return dataPacket[_position];
+}
+

--- a/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibrarySupport.cpp
+++ b/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibrarySupport.cpp
@@ -326,8 +326,8 @@ byte powerSTEP::SPIXfer(byte data)
     dataPacket[i] = 0;
   }
   dataPacket[_position] = data;
-  digitalWrite(_CSPin, LOW);
-  _SPI->beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE3));
+  digitalWrite(_CSPin, LOW);  
+  _SPI->beginTransaction(SPISettings(500000, MSBFIRST, SPI_MODE3));
   _SPI->transfer(dataPacket, _numBoards);
   _SPI->endTransaction();
   digitalWrite(_CSPin, HIGH);

--- a/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibrarySupport.cpp
+++ b/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ArduinoLibrarySupport.cpp
@@ -327,7 +327,7 @@ byte powerSTEP::SPIXfer(byte data)
   }
   dataPacket[_position] = data;
   digitalWrite(_CSPin, LOW);  
-  _SPI->beginTransaction(SPISettings(500000, MSBFIRST, SPI_MODE3));
+  _SPI->beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE3));
   _SPI->transfer(dataPacket, _numBoards);
   _SPI->endTransaction();
   digitalWrite(_CSPin, HIGH);

--- a/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ConfigurationStructures.h
+++ b/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01ConfigurationStructures.h
@@ -1,0 +1,93 @@
+#include "powerSTEP01ArduinoLibrary.h"
+
+struct basicPowerSTEP01Configuration
+{
+  float maxSpeed;
+
+  byte overCurrentThreshold;
+
+  byte runKval;
+  byte holdKval;
+
+  void Reset()
+  {
+    maxSpeed = 500;
+    
+    overCurrentThreshold = 20;
+    
+    runKval = 64;
+    holdKval = 32;
+  }
+};
+
+struct powerSTEP01Configuration
+{
+  byte syncPinMode;
+  byte syncDivisor;
+
+  byte stepMode;
+
+  float maxSpeed;
+  float minSpeed;
+  float fullStepsSpeed;
+  float acceleration;
+  float deceleration;
+
+  int slewRate;
+
+  byte overCurrentThreshold;
+  int overCurrentShutdown;
+
+  int pwmDivisor;
+  int pwmMultiplier;
+
+  int voltageCompensation;
+
+  int switchMode;
+
+  int clockSource;
+
+  byte runKval;
+  byte accelerationKval;
+  byte decelerationKval;
+  byte holdKval;
+
+  byte alarmEn;
+
+  void Reset()
+  {
+    syncPinMode = BUSY_PIN;
+    syncDivisor = 0;
+    
+    stepMode = STEP_FS_128;
+    
+    maxSpeed = 500;
+    minSpeed = 0;
+    fullStepsSpeed = 500;
+    acceleration = 1000;
+    deceleration = 1000;
+  
+    slewRate = SR_520V_us;
+  
+    overCurrentThreshold = 20;
+    overCurrentShutdown = OC_SD_DISABLE;
+  
+    pwmDivisor = PWM_DIV_1;
+    pwmMultiplier = PWM_MUL_1;
+  
+    voltageCompensation = VS_COMP_DISABLE;
+  
+    switchMode = SW_HARD_STOP;
+  
+    clockSource = INT_16MHZ;
+  
+    runKval = 64;
+    accelerationKval = 64;
+    decelerationKval = 64;
+    holdKval = 32;
+
+    alarmEn = 0xEF;
+  }
+};
+
+

--- a/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01SPINConstants.h
+++ b/firmware/step400_OSCtester/step400_OSCtester/powerSTEP01SPINConstants.h
@@ -1,0 +1,202 @@
+#ifndef _dspin_constants_h_
+#define _dspin_constants_h_
+
+// Constant definitions provided by ST
+
+// STEP_MODE option values.
+// First comes the "microsteps per step" options...
+#define STEP_MODE_STEP_SEL 0x07  // Mask for these bits only.
+#define STEP_SEL_1     0x00
+#define STEP_SEL_1_2   0x01
+#define STEP_SEL_1_4   0x02
+#define STEP_SEL_1_8   0x03
+#define STEP_SEL_1_16  0x04
+#define STEP_SEL_1_32  0x05
+#define STEP_SEL_1_64  0x06
+#define STEP_SEL_1_128 0x07
+
+// ...next, define the SYNC_EN bit. When set, the BUSYN pin will instead
+//  output a clock related to the full-step frequency as defined by the
+//  SYNC_SEL bits below.
+#define STEP_MODE_SYNC_EN	 0x80  // Mask for this bit
+#define SYNC_EN 0x80
+
+// ...last, define the SYNC_SEL modes. The clock output is defined by
+//  the full-step frequency and the value in these bits- see the datasheet
+//  for a matrix describing that relationship (page 46).
+#define STEP_MODE_SYNC_SEL 0x70
+#define SYNC_SEL_1_2 0x00
+#define SYNC_SEL_1   0x10
+#define SYNC_SEL_2   0x20
+#define SYNC_SEL_4   0x30
+#define SYNC_SEL_8   0x40
+#define SYNC_SEL_16  0x50
+#define SYNC_SEL_32  0x60
+#define SYNC_SEL_64  0x70
+
+// Bit names for the ALARM_EN register.
+//  Each of these bits defines one potential alarm condition.
+//  When one of these conditions occurs and the respective bit in ALARM_EN is set,
+//  the FLAG pin will go low. The register must be queried to determine which event
+//  caused the alarm.
+#define ALARM_EN_OVERCURRENT       0x01
+#define ALARM_EN_THERMAL_SHUTDOWN	 0x02
+#define ALARM_EN_THERMAL_WARNING   0x04
+#define ALARM_EN_UNDER_VOLTAGE     0x08
+#define ALARM_EN_STALL_DET_A       0x10
+#define ALARM_EN_STALL_DET_B       0x20
+#define ALARM_EN_SW_TURN_ON        0x40
+#define ALARM_EN_WRONG_NPERF_CMD   0x80
+
+// CONFIG register renames.
+
+// Oscillator options.
+// The dSPIN needs to know what the clock frequency is because it uses that for some
+//  calculations during operation.
+#define CONFIG_OSC_SEL                 0x000F // Mask for this bit field.
+#define CONFIG_INT_16MHZ               0x0000 // Internal 16MHz, no output
+#define CONFIG_INT_16MHZ_OSCOUT_2MHZ   0x0008 // Default; internal 16MHz, 2MHz output
+#define CONFIG_INT_16MHZ_OSCOUT_4MHZ   0x0009 // Internal 16MHz, 4MHz output
+#define CONFIG_INT_16MHZ_OSCOUT_8MHZ   0x000A // Internal 16MHz, 8MHz output
+#define CONFIG_INT_16MHZ_OSCOUT_16MHZ  0x000B // Internal 16MHz, 16MHz output
+#define CONFIG_EXT_8MHZ_XTAL_DRIVE     0x0004 // External 8MHz crystal
+#define CONFIG_EXT_16MHZ_XTAL_DRIVE    0x0005 // External 16MHz crystal
+#define CONFIG_EXT_24MHZ_XTAL_DRIVE    0x0006 // External 24MHz crystal
+#define CONFIG_EXT_32MHZ_XTAL_DRIVE    0x0007 // External 32MHz crystal
+#define CONFIG_EXT_8MHZ_OSCOUT_INVERT  0x000C // External 8MHz crystal, output inverted
+#define CONFIG_EXT_16MHZ_OSCOUT_INVERT 0x000D // External 16MHz crystal, output inverted
+#define CONFIG_EXT_24MHZ_OSCOUT_INVERT 0x000E // External 24MHz crystal, output inverted
+#define CONFIG_EXT_32MHZ_OSCOUT_INVERT 0x000F // External 32MHz crystal, output inverted
+
+// Configure the functionality of the external switch input
+#define CONFIG_SW_MODE                 0x0010 // Mask for this bit.
+#define CONFIG_SW_HARD_STOP            0x0000 // Default; hard stop motor on switch.
+#define CONFIG_SW_USER                 0x0010 // Tie to the GoUntil and ReleaseSW
+                                                    //  commands to provide jog function.
+                                                    //  See page 25 of datasheet.
+
+// Configure the motor voltage compensation mode (see page 34 of datasheet)
+#define CONFIG_EN_VSCOMP               0x0020  // Mask for this bit.
+#define CONFIG_VS_COMP_DISABLE         0x0000  // Disable motor voltage compensation.
+#define CONFIG_VS_COMP_ENABLE          0x0020  // Enable motor voltage compensation.
+
+// Configure overcurrent detection event handling
+#define CONFIG_OC_SD                   0x0080  // Mask for this bit.
+#define CONFIG_OC_SD_DISABLE           0x0000  // Bridges do NOT shutdown on OC detect
+#define CONFIG_OC_SD_ENABLE            0x0080  // Bridges shutdown on OC detect
+
+// Configure the UVLO protection thresholds
+#define CONFIG_UVLOVAL                 0x0100 // Mask for this bit.
+#define CONFIG_UVLOVAL_LOW             0x0000 // V_ccth 6.9V-6.3V, DV_BOOTTh 6V-5.5V
+#define CONFIG_UVLOVAL_HIGH            0x0200 // V_ccth 10.4V-10, DV_BOOTTh 9.2V-8.8V
+
+// Configure the Vcc voltage regulator output
+#define CONFIG_VCCVAL                  0x0200 // Mask for this bit.
+#define CONFIG_VCCVAL_7_5V             0x0000 // 7.5V Vcc output
+#define CONFIG_VCCVAL_15V              0x0200 // 15V Vcc output
+
+// Integer divisors for PWM sinewave generation
+//  See page 32 of the datasheet for more information on this.
+#define CONFIG_F_PWM_DEC               0x1C00      // mask for this bit field
+#define CONFIG_PWM_MUL_0_625           (0x00)<<10
+#define CONFIG_PWM_MUL_0_75            (0x01)<<10
+#define CONFIG_PWM_MUL_0_875           (0x02)<<10
+#define CONFIG_PWM_MUL_1               (0x03)<<10
+#define CONFIG_PWM_MUL_1_25            (0x04)<<10
+#define CONFIG_PWM_MUL_1_5             (0x05)<<10
+#define CONFIG_PWM_MUL_1_75            (0x06)<<10
+#define CONFIG_PWM_MUL_2               (0x07)<<10
+
+// Multiplier for the PWM sinewave frequency
+#define CONFIG_F_PWM_INT               0xE000     // mask for this bit field.
+#define CONFIG_PWM_DIV_1               (0x00)<<13
+#define CONFIG_PWM_DIV_2               (0x01)<<13
+#define CONFIG_PWM_DIV_3               (0x02)<<13
+#define CONFIG_PWM_DIV_4               (0x03)<<13
+#define CONFIG_PWM_DIV_5               (0x04)<<13
+#define CONFIG_PWM_DIV_6               (0x05)<<13
+#define CONFIG_PWM_DIV_7               (0x06)<<13
+
+// Status register bit renames- read-only bits conferring information about the
+//  device to the user.
+#define STATUS_HIZ                     0x0001 // high when bridges are in HiZ mode
+#define STATUS_BUSY                    0x0002 // mirrors BUSY pin
+#define STATUS_SW_F                    0x0004 // low when switch open, high when closed
+#define STATUS_SW_EVN                  0x0008 // active high, set on switch falling edge,
+                                                    //  cleared by reading STATUS
+#define STATUS_DIR                     0x0010 // Indicates current motor direction.
+                                                    //  High is FWD, Low is REV.
+#define STATUS_NOTPERF_CMD             0x0080 // Last command not performed.
+#define STATUS_WRONG_CMD               0x0100 // Last command not valid.
+#define STATUS_UVLO                    0x0200 // Undervoltage lockout is active
+#define STATUS_TH_WRN                  0x0400 // Thermal warning
+#define STATUS_TH_SD                   0x0800 // Thermal shutdown
+#define STATUS_OCD                     0x1000 // Overcurrent detected
+#define STATUS_STEP_LOSS_A             0x2000 // Stall detected on A bridge
+#define STATUS_STEP_LOSS_B             0x4000 // Stall detected on B bridge
+#define STATUS_SCK_MOD                 0x8000 // Step clock mode is active
+
+// Status register motor status field
+#define STATUS_MOT_STATUS                0x0060      // field mask
+#define STATUS_MOT_STATUS_STOPPED       (0x0000)<<13 // Motor stopped
+#define STATUS_MOT_STATUS_ACCELERATION  (0x0001)<<13 // Motor accelerating
+#define STATUS_MOT_STATUS_DECELERATION  (0x0002)<<13 // Motor decelerating
+#define STATUS_MOT_STATUS_CONST_SPD     (0x0003)<<13 // Motor at constant speed
+
+// Register address redefines.
+//  See the Param_Handler() function for more info about these.
+#define ABS_POS              0x01
+#define EL_POS               0x02
+#define MARK                 0x03
+#define SPEED                0x04
+#define ACC                  0x05
+#define DECEL                0x06
+#define MAX_SPEED            0x07
+#define MIN_SPEED            0x08
+#define FS_SPD               0x15
+#define KVAL_HOLD            0x09
+#define KVAL_RUN             0x0A
+#define KVAL_ACC             0x0B
+#define KVAL_DEC             0x0C
+#define TVAL_HOLD            0x09
+#define TVAL_RUN             0x0A
+#define TVAL_ACC             0x0B
+#define TVAL_DEC             0x0C
+#define INT_SPD              0x0D
+#define ST_SLP               0x0E
+#define FN_SLP_ACC           0x0F
+#define FN_SLP_DEC           0x10
+#define K_THERM              0x11
+#define ADC_OUT              0x12
+#define OCD_TH               0x13
+#define STALL_TH             0x14
+#define STEP_MODE            0x16
+#define ALARM_EN             0x17
+#define GATECFG1             0x18
+#define GATECFG2             0x19
+#define CONFIG               0x1A
+#define STATUS               0x1B
+
+//dSPIN commands
+#define NOP                  0x00
+#define SET_PARAM            0x00
+#define GET_PARAM            0x20
+#define RUN                  0x50
+#define STEP_CLOCK           0x58
+#define MOVE                 0x40
+#define GOTO                 0x60
+#define GOTO_DIR             0x68
+#define GO_UNTIL             0x82
+#define RELEASE_SW           0x92
+#define GO_HOME              0x70
+#define GO_MARK              0x78
+#define RESET_POS            0xD8
+#define RESET_DEVICE         0xC0
+#define SOFT_STOP            0xB0
+#define HARD_STOP            0xB8
+#define SOFT_HIZ             0xA0
+#define HARD_HIZ             0xA8
+#define GET_STATUS           0xD0
+
+#endif
+

--- a/firmware/step400_OSCtester/step400_OSCtester/step400_OSCtester.ino
+++ b/firmware/step400_OSCtester/step400_OSCtester/step400_OSCtester.ino
@@ -458,7 +458,7 @@ void goToDir(OSCMessage &msg ,int addrOffset) {
 	unsigned long pos = msg.getInt(2);
 	powerSteps[target].goToDir(dir, pos);
 }
-// todo: action�ĂȂ�
+// todo: action‚Ä‚È‚É
 void goUntil(OSCMessage &msg ,int addrOffset) {
 	uint8_t target = constrain(msg.getInt(0), 0, 3);
 	uint8_t action = msg.getInt(1);

--- a/firmware/step400_OSCtester/step400_OSCtester/step400_OSCtester.ino
+++ b/firmware/step400_OSCtester/step400_OSCtester/step400_OSCtester.ino
@@ -613,7 +613,7 @@ void statusCheck()
 			uint8_t busy = (status & 0b10) >> 1;
 			uint8_t dir = (status & 0b10000) >> 4;
 
-			if (i == 0 && status != 0b1110001000010011) {
+			if (i == 0 && status != 0b1110001000000111) {
 				SerialUSB.println(status, BIN);
 				SerialUSB.print(sw);
 				SerialUSB.print(" ");

--- a/firmware/step400_OSCtester/step400_OSCtester/step400_OSCtester.ino
+++ b/firmware/step400_OSCtester/step400_OSCtester/step400_OSCtester.ino
@@ -4,12 +4,12 @@
 * Created: 9/19/2019 4:53:04 PM
 * Author: kanta
 */
-
+#include <cstdint>
 #include <Arduino.h>
 #include <Ethernet.h>
 #include <OSCMessage.h>
 //#include <powerSTEP01ArduinoLibrary.h>
-#include "LocalLibraries/powerSTEP01_Arduino_Library/src/powerSTEP01ArduinoLibrary.h"
+#include "powerSTEP01ArduinoLibrary.h"
 #include <SPI.h>
 #include "wiring_private.h" // pinPeripheral() function
 
@@ -59,7 +59,7 @@ void setup()
 	pinMode(SD_CS, OUTPUT);
 
 	// Start serial
-	SerialUSB.begin(9600);
+	SerialUSB.begin(115200);
 	SerialUSB.println("powerSTEP01 Arduino control initialising...");
 
 	// Prepare pins
@@ -613,7 +613,8 @@ void statusCheck()
 			uint8_t busy = (status & 0b10) >> 1;
 			uint8_t dir = (status & 0b10000) >> 4;
 
-			if (i == 0 && status != 0b1110001000000111) {
+			const uint8_t mask = 0xFF;
+			if (i == 0 && !(status & mask)) {
 				SerialUSB.println(status, BIN);
 				SerialUSB.print(sw);
 				SerialUSB.print(" ");


### PR DESCRIPTION
SPI通信デバッグの現状です。通信速度は元の4MHzに戻してあります。
多数決方式と重要な値を拾いたい場合と両方できるようにしてみました。

ここで、どちらの方式を使うか、それぞれのビットで設定できます。
https://github.com/kanta/STEP400/blob/debug/SPI_Status/firmware/step400_OSCtester/step400_OSCtester/step400_OSCtester.ino#L670-L685